### PR TITLE
return Change enum if byte was flipped

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ extern crate memory_pager;
 use memory_pager::Pager;
 
 /// Bitfield instance.
+#[derive(Debug)]
 pub struct Bitfield {
   /// The [`page_size`] of the `Page` instances stored in [memory-pager].
   ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 #![cfg_attr(test, plugin(clippy))]
 
 /// Determine wether the `bitfield.set()` method changed the underlying value.
+#[derive(Debug, PartialEq)]
 pub enum Change {
   /// The value was changed.
   Changed,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,16 +48,17 @@ impl Bitfield {
     }
   }
 
-  /// Set a bit to true or false.
-  pub fn set(&mut self, index: usize, value: bool) {
+  /// Set a byte to true or false. Returns a boolean indicating if the value was
+  /// changed.
+  pub fn set(&mut self, index: usize, value: bool) -> bool {
     let masked_index = index & 7;
     let j = (index - masked_index) / 8;
     let b = self.get_byte(j);
 
     if value {
-      self.set_byte(j, b | (128 >> masked_index));
+      self.set_byte(j, b | (128 >> masked_index))
     } else {
-      self.set_byte(j, b & (255 ^ (128 >> masked_index)));
+      self.set_byte(j, b & (255 ^ (128 >> masked_index)))
     }
   }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -17,7 +17,7 @@ fn basic_set_get() {
 #[test]
 fn can_set_bits() {
   let mut bits = Bitfield::new(1024);
-  bits.set(1_00, true);
+  bits.set(100, true);
   bits.set(1_000, true);
   bits.set(1_000_000, true);
   bits.set(1_000_000_000, true);
@@ -29,7 +29,17 @@ fn can_get_bits() {
   let mut bits = Bitfield::new(1024);
   bits.set(0, true);
   bits.set(1, true);
-  bits.set(1_000, true);
+  bits.set(1000, true);
   assert_eq!(bits.get(0), true);
   assert_eq!(bits.get(1), true);
+}
+
+#[test]
+fn returns_if_flipped() {
+  let mut bits = Bitfield::new(1024);
+  assert_eq!(bits.set(0, true), true);
+  assert_eq!(bits.set(0, false), true);
+  assert_eq!(bits.set(0, true), true);
+  assert_eq!(bits.set(0, true), false);
+  assert_eq!(bits.set(0, true), false);
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,6 @@
 extern crate sparse_bitfield;
 
-use sparse_bitfield::Bitfield;
+use sparse_bitfield::{Bitfield, Change};
 
 #[test]
 fn can_create_bitfield() {
@@ -37,9 +37,9 @@ fn can_get_bits() {
 #[test]
 fn returns_if_flipped() {
   let mut bits = Bitfield::new(1024);
-  assert_eq!(bits.set(0, true), true);
-  assert_eq!(bits.set(0, false), true);
-  assert_eq!(bits.set(0, true), true);
-  assert_eq!(bits.set(0, true), false);
-  assert_eq!(bits.set(0, true), false);
+  assert_eq!(bits.set(0, true), Change::Changed);
+  assert_eq!(bits.set(0, false), Change::Changed);
+  assert_eq!(bits.set(0, true), Change::Changed);
+  assert_eq!(bits.set(0, true), Change::Unchanged);
+  assert_eq!(bits.set(0, true), Change::Unchanged);
 }


### PR DESCRIPTION
Was needed for hypercore. Returns whether a byte was changed.