### PR TITLE
Fix length calculation and some cleanup

### DIFF
--- a/src/change.rs
+++ b/src/change.rs
@@ -1,4 +1,4 @@
-/// Determine wether the `bitfield.set()` method changed the underlying value.
+/// Determine whether the `bitfield.set()` method changed the underlying value.
 #[derive(Debug, PartialEq)]
 pub enum Change {
   /// The value was changed. Equal to `true` in `mafintosh/sparse-bitfield`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,7 @@ impl Bitfield {
   /// Get the amount of bits in the bitfield.
   #[inline]
   pub fn len(&self) -> usize {
-    self.length
+    self.length * 8
   }
 
   /// Returns `true` if no bits are stored.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ impl Bitfield {
 
   #[inline]
   fn page_mask(&self, index: usize) -> usize {
-    index & self.page_size() - 1
+    index & (self.page_size() - 1)
   }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,11 @@ impl Bitfield {
   /// ## Panics
   /// Panics if the page size is not a power of two (2, 4, 8, etc.)
   pub fn new(page_size: usize) -> Self {
-    assert!(is_power_of_two(page_size));
+    assert!(
+      is_power_of_two(page_size),
+      "page_size must be a power of two: {}",
+      page_size
+    );
     Bitfield {
       pages: Pager::new(page_size),
       length: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,9 +99,6 @@ impl Bitfield {
     }
 
     page[masked_index] = byte;
-    if index >= self.length {
-      self.length = index + 1;
-    }
 
     Change::Changed
   }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@ pub struct Bitfield {
   pub pages: Pager,
 
   length: usize,
-  page_length: usize,
 }
 
 /// Create a new instance with a `page_size` of `1kb`.
@@ -42,7 +41,6 @@ impl Bitfield {
     assert!(is_power_of_two(page_size));
     Bitfield {
       pages: Pager::new(page_size),
-      page_length: 0,
       length: 0,
     }
   }

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -4,7 +4,7 @@ use sparse_bitfield::{Bitfield, Change};
 
 // src/lib.rs::is_even was incorrectly flagging 6 as odd.
 #[test]
-#[should_panic] // 6 is not a power of 2, which later became a constraint
+#[should_panic(expected = "page_size must be a power of two")] // 6 is not a power of 2, which later became a constraint
 fn regression_01() {
   let mut bits = Bitfield::new(6);
   assert_eq!(bits.set(0, true), Change::Changed);
@@ -14,7 +14,7 @@ fn regression_01() {
 // we learned that we actually need the Bitfield to have a
 // page size that is a POWER of two, not a multiple.
 #[test]
-#[should_panic]
+#[should_panic(expected = "page_size must be a power of two")]
 fn regression_02() {
   let mut bits = Bitfield::new(2566);
   assert_eq!(bits.set(332288, true), Change::Changed);

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -56,16 +56,34 @@ fn can_iterate() {
   let mut bits = Bitfield::new(1024);
 
   bits.set(0, true);
-  for bit in bits.iter() {
-    assert_eq!(bit, true, "one bit, value true");
+  for (i, bit) in bits.iter().enumerate() {
+    assert_eq!(bit, i == 0, "one bit, value true");
   }
 
   bits.set(1, false);
   for (i, bit) in bits.iter().enumerate() {
     match i {
       0 => assert!(bit),
-      1 => assert!(!bit),
+      1...7 => assert!(!bit, "{:?}", (i, bit)),
       i => panic!("index {} out of bounds", i),
     }
   }
+}
+
+#[test]
+fn len_is_correct() {
+  let mut bits = Bitfield::new(1024);
+  assert_eq!(bits.len(), 0);
+
+  bits.set(0, true);
+  assert_eq!(bits.len(), 8);
+
+  bits.set_byte(10, 0x00);
+  assert_eq!(bits.len(), 88);
+
+  bits.set_byte(20, 0xff);
+  assert_eq!(bits.len(), 168);
+
+  bits.set(1_000_000_000, true);
+  assert_eq!(bits.len(), 1_000_000_008);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,7 +11,7 @@ fn can_create_bitfield() {
 fn basic_set_get() {
   let mut bits = Bitfield::new(1024);
   bits.set(0, true);
-  assert!(bits.get(0), true);
+  assert!(bits.get(0));
 }
 
 #[test]
@@ -63,8 +63,8 @@ fn can_iterate() {
   bits.set(1, false);
   for (i, bit) in bits.iter().enumerate() {
     match i {
-      0 => assert!(bit, true),
-      1 => assert!(bit, false),
+      0 => assert!(bit),
+      1 => assert!(!bit),
       i => panic!("index {} out of bounds", i),
     }
   }


### PR DESCRIPTION
This a 🐛 bug fix.

The doc says `len()` is the number of bits and this matches the code
in https://github.com/mafintosh/sparse-bitfield.git

## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
