### PR TITLE
set the bit correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
 readme = "README.md"
 
 [dependencies]
-memory-pager = "0.7.0"
-failure = "0.1.1"
+memory-pager = "0.8.0"
+failure = "0.1.2"
 
 [dev-dependencies]
 proptest = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ impl Bitfield {
     })
   }
 
-  /// Set a byte to true or false. Returns a boolean indicating if the value was
+  /// Set a bit to true or false. Returns a boolean indicating if the value was
   /// changed.
   #[inline]
   pub fn set(&mut self, index: usize, value: bool) -> Change {
@@ -110,7 +110,7 @@ impl Bitfield {
   #[inline]
   pub fn set_byte(&mut self, index: usize, byte: u8) -> Change {
     let byte_offset = self.page_mask(index);
-    let page_num = (index - byte_offset) / self.page_size();
+    let page_num = index / self.page_size();
     let page = self.pages.get_mut_or_alloc(page_num);
 
     if index >= self.byte_length {

--- a/tests/fixtures/40_normal.txt
+++ b/tests/fixtures/40_normal.txt
@@ -1,0 +1,1 @@
+abcdefghijabcdefghijabcdefghijabcdefghij

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,9 @@
 extern crate sparse_bitfield;
+extern crate failure;
 
 use sparse_bitfield::{Bitfield, Change};
+use std::fs;
+use failure::Error;
 
 #[test]
 fn can_create_bitfield() {
@@ -76,4 +79,16 @@ fn can_iterate() {
 
   let arr: Vec<bool> = bits.iter().collect();
   assert_eq!(arr.len(), 8);
+}
+
+#[test]
+fn from_file() -> Result<(), Error> {
+  let page_size = 10;
+  let mut file = fs::File::open("./tests/fixtures/40_normal.txt")?;
+  let mut bits = Bitfield::from_file(&mut file, page_size, None)?;
+  bits.set(100, false);
+  assert_eq!(bits.page_len(), 4);
+  assert_eq!(bits.len(), 320);
+  assert_eq!(bits.get(100), false);
+  Ok(()) 
 }


### PR DESCRIPTION
Signed-off-by: ZhouHansen <z308114274@gmail.com>

This is a 🐛 bug fix.

When set a bit which is not within the first page, the calculation is wrong. 

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
None

## Semver Changes
Patch
