### PR TITLE
Keep up with modern times in clippy invocation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ rust:
 
 before_script: |
   rustup component add rustfmt-preview &&
-  cargo install clippy -f
+  rustup component add clippy-preview
 script: |
   cargo fmt -- --check &&
-  cargo clippy -- -D clippy &&
+  cargo clippy -- -D clippy::all &&
   cargo build --verbose &&
   cargo test  --verbose
 cache: cargo

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,9 +1,9 @@
-extern crate sparse_bitfield;
 extern crate failure;
+extern crate sparse_bitfield;
 
+use failure::Error;
 use sparse_bitfield::{Bitfield, Change};
 use std::fs;
-use failure::Error;
 
 #[test]
 fn can_create_bitfield() {
@@ -90,5 +90,5 @@ fn from_file() -> Result<(), Error> {
   assert_eq!(bits.page_len(), 4);
   assert_eq!(bits.len(), 320);
   assert_eq!(bits.get(100), false);
-  Ok(()) 
+  Ok(())
 }


### PR DESCRIPTION
This is a 🐛 bug fix.

Fixes the following warning:
`warning: lint name `clippy` is deprecated and does not have an effect anymore. Use: clippy::all`

## Checklist

- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Semver Changes
None