### PR TITLE
Bump to 2018 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: rust
 rust:
-  - nightly
+  - stable
 
 before_script: |
-  rustup component add rustfmt-preview &&
-  rustup component add clippy-preview
+  rustup component add rustfmt &&
+  rustup component add clippy
 script: |
   cargo fmt -- --check &&
   cargo clippy -- -D clippy::all &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
-name = "sparse-bitfield"
-version = "0.10.0"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/datrs/sparse-bitfield"
-documentation = "https://docs.rs/sparse-bitfield"
-description = "Bitfield that allocates a series of small buffers"
-authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
-readme = "README.md"
+name = 'sparse-bitfield'
+version = '0.10.0'
+license = 'MIT OR Apache-2.0'
+repository = 'https://github.com/datrs/sparse-bitfield'
+documentation = 'https://docs.rs/sparse-bitfield'
+description = 'Bitfield that allocates a series of small buffers'
+authors = ['Yoshua Wuyts <yoshuawuyts@gmail.com>']
+readme = 'README.md'
+edition = '2018'
 
 [dependencies]
-memory-pager = "0.9.0"
+memory-pager = '0.9.0'
 
 [dev-dependencies]
-proptest = "0.9.0"
+proptest = '0.9.5'
+failure = '0.1.6'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,11 @@
 #![cfg_attr(nightly, doc(include = "../README.md"))]
 #![cfg_attr(test, deny(warnings))]
 
-extern crate memory_pager;
-
 mod change;
 mod iter;
 
-pub use change::Change;
-pub use iter::Iter;
+pub use crate::change::Change;
+pub use crate::iter::Iter;
 
 use memory_pager::Pager;
 use std::fs::File;

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,6 +1,4 @@
-extern crate sparse_bitfield;
-#[macro_use]
-extern crate proptest;
+use proptest::proptest;
 
 use sparse_bitfield::{Bitfield, Change};
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,5 +1,3 @@
-extern crate sparse_bitfield;
-
 use sparse_bitfield::{Bitfield, Change};
 
 // src/lib.rs::is_even was incorrectly flagging 6 as odd.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,3 @@
-extern crate failure;
-extern crate sparse_bitfield;
-
 use failure::Error;
 use sparse_bitfield::{Bitfield, Change};
 use std::fs;


### PR DESCRIPTION
This commit bumps the code to use Rust 2018.

<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:**  a 🙋 feature

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->

## Semver Changes
<!-- Which semantic version change would you recommend? -->
patch