### PR TITLE
To bytes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: rust
 rust:
-  - nightly
+  - stable
 
 before_script: |
-  rustup component add rustfmt-preview &&
-  rustup component add clippy-preview
+  rustup component add rustfmt &&
+  rustup component add clippy
 script: |
   cargo fmt -- --check &&
   cargo clippy -- -D clippy::all &&

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,17 @@
 [package]
-name = "sparse-bitfield"
-version = "0.10.0"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/datrs/sparse-bitfield"
-documentation = "https://docs.rs/sparse-bitfield"
-description = "Bitfield that allocates a series of small buffers"
-authors = ["Yoshua Wuyts <yoshuawuyts@gmail.com>"]
-readme = "README.md"
+name = 'sparse-bitfield'
+version = '0.10.0'
+license = 'MIT OR Apache-2.0'
+repository = 'https://github.com/datrs/sparse-bitfield'
+documentation = 'https://docs.rs/sparse-bitfield'
+description = 'Bitfield that allocates a series of small buffers'
+authors = ['Yoshua Wuyts <yoshuawuyts@gmail.com>']
+readme = 'README.md'
+edition = '2018'
 
 [dependencies]
-memory-pager = "0.9.0"
+memory-pager = '0.9.0'
 
 [dev-dependencies]
-proptest = "0.9.0"
+proptest = '0.9.5'
+failure = '0.1.6'

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,13 +3,11 @@
 #![cfg_attr(nightly, doc(include = "../README.md"))]
 #![cfg_attr(test, deny(warnings))]
 
-extern crate memory_pager;
-
 mod change;
 mod iter;
 
-pub use change::Change;
-pub use iter::Iter;
+pub use crate::change::Change;
+pub use crate::iter::Iter;
 
 use memory_pager::Pager;
 use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,6 +217,25 @@ impl Bitfield {
   fn page_mask(&self, index: usize) -> usize {
     index & (self.page_size() - 1)
   }
+
+  /// Based on [Bitfield.prototype.toBuffer](https://github.com/mafintosh/sparse-bitfield/blob/master/index.js#L54-L64)
+  pub fn to_bytes(&self) -> std::io::Result<Vec<u8>> {
+    use std::io::{Cursor, Write};
+
+    let mut all =
+      Cursor::new(Vec::with_capacity(self.page_len() * self.page_size()));
+
+    for index in 0..self.page_len() {
+      let next = self.pages.get(index);
+      if let Some(page) = next {
+        let all_offset = index * self.page_size();
+        all.set_position(all_offset as u64);
+        all.write(&page)?;
+      }
+    }
+
+    Ok(all.into_inner())
+  }
 }
 
 /// Create a new instance with a `page_size` of `1kb`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ impl Bitfield {
       if let Some(page) = next {
         let all_offset = index * self.page_size();
         all.set_position(all_offset as u64);
-        all.write(&page)?;
+        all.write_all(&page)?;
       }
     }
 

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,6 +1,4 @@
-extern crate sparse_bitfield;
-#[macro_use]
-extern crate proptest;
+use proptest::proptest;
 
 use sparse_bitfield::{Bitfield, Change};
 

--- a/tests/regression.rs
+++ b/tests/regression.rs
@@ -1,5 +1,3 @@
-extern crate sparse_bitfield;
-
 use sparse_bitfield::{Bitfield, Change};
 
 // src/lib.rs::is_even was incorrectly flagging 6 as odd.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,6 +1,3 @@
-extern crate failure;
-extern crate sparse_bitfield;
-
 use failure::Error;
 use sparse_bitfield::{Bitfield, Change};
 use std::fs;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -79,6 +79,26 @@ fn can_iterate() {
 }
 
 #[test]
+fn can_convert_to_bytes_buffer() {
+  let mut bits = Bitfield::new(1024);
+
+  assert_eq!(bits.to_bytes().unwrap(), vec![]);
+
+  bits.set(0, true);
+
+  assert_eq!(
+    &bits.to_bytes().unwrap(),
+    &bits.pages.get(0).unwrap().as_ref()
+  );
+
+  bits.set(9000, true);
+
+  let mut concat_pages = bits.pages.get(0).unwrap().as_ref().to_vec();
+  concat_pages.extend_from_slice(&bits.pages.get(1).unwrap().as_ref());
+  assert_eq!(bits.to_bytes().unwrap(), concat_pages);
+}
+
+#[test]
 fn from_file() -> Result<(), Error> {
   let page_size = 10;
   let mut file = fs::File::open("./tests/fixtures/40_normal.txt")?;


### PR DESCRIPTION
Even tho #2 was closed
with the iter implementation, it was not enought to use with
`bitfield-rle` crate.

The crate takes a `AsRef<[u8]>` to encode, and the iterator returns a
set of `bool`. This code uses the `Bitfield.prototype.toBuffer` logic to
create the `to_bytes` method.
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**Choose one:** a 🙋 feature

<!-- Provide a general summary of the changes in the title above -->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
<!-- Is this related to any GitHub issue(s)? -->
Built on top of https://github.com/datrs/sparse-bitfield/pull/16

## Semver Changes
<!-- Which semantic version change would you recommend? -->
minor
